### PR TITLE
1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.nyc_output
+gitignore
 node_modules
 reports
-gitignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "node"
+  - "iojs"
+  - "4"
+  - "5"
+  - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,3 @@ node_js:
   - "4"
   - "5"
   - "6"
-script: npm run lint && npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ node_js:
   - "4"
   - "5"
   - "6"
+script: npm run lint && npm test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Build Status](https://travis-ci.org/zachrose/barrel.svg?branch=master)](https://travis-ci.org/zachrose/barrel)
+[![Dependencies](https://david-dm.org/zachrose/barrel/status.svg)](https://david-dm.org/zachrose/barrel)
+[![Dev Dependencies](https://david-dm.org/zachrose/barrel/dev-status.svg)](https://david-dm.org/zachrose/barrel?type=dev)
 
 Everyone knows that time-based things can be done with setTimeout in JavaScript:
 
@@ -38,7 +40,3 @@ document.getElementById('pause').onclick = function(){ player.pause() };
 ```
 
 So far this is all pretty abstract, but that's on purpose. With some imagination, you can use Barrel to work with timed event sequences of any kind: a dancing hamster on a web page, a loading animation, or a Node.js-ignited firework display.
-
-Separating things out into a player and a sequence has a few neat side-effects. Barrel doesn't do this for you, but it's relatively straightforward to write an HTML template and some CSS that transforms an event sequence into a visual representation. Additional work to make that representation interactive would result in an editor. Sequences can also be analyzed and transformed in interesting ways with the functional JavaScript tool belt of your choice.
-
-At this time Barrel depends on the [events](https://www.npmjs.org/package/events) npm module to emit a 'tick' event at a given interval of time while playing. I haven't tried to figure out how to make it work in a browser without Browserify.

--- a/demos/cli.js
+++ b/demos/cli.js
@@ -1,21 +1,23 @@
-Player = require('../lib/player');
+'use strict';
 
-player = new Player(function(d){
+var Player = require('../lib/player');
+
+new Player(function(d){
   console.log(d);
 }).load([
-  { time: 1.2*0,     data: "Come" },
-  { time: 1.2*500,   data: "as" },
-  { time: 1.2*750,   data: "you" },
-  { time: 1.2*875,   data: "are" },
-  { time: 1.2*1500,  data: "as" },
-  { time: 1.2*1750,  data: "you" },
-  { time: 1.2*1825,  data: "were" },
-  { time: 1.2*2675,  data: "as" },
-  { time: 1.2*2750,  data: "I" },
-  { time: 1.2*2850,  data: "want" },
-  { time: 1.2*3000,  data: "you" },
-  { time: 1.2*3250,  data: "to" },
-  { time: 1.2*3500,  data: "be" },
+  { time: 1.2*0,     data: 'Come' },
+  { time: 1.2*500,   data: 'as' },
+  { time: 1.2*750,   data: 'you' },
+  { time: 1.2*875,   data: 'are' },
+  { time: 1.2*1500,  data: 'as' },
+  { time: 1.2*1750,  data: 'you' },
+  { time: 1.2*1825,  data: 'were' },
+  { time: 1.2*2675,  data: 'as' },
+  { time: 1.2*2750,  data: 'I' },
+  { time: 1.2*2850,  data: 'want' },
+  { time: 1.2*3000,  data: 'you' },
+  { time: 1.2*3250,  data: 'to' },
+  { time: 1.2*3500,  data: 'be' },
 ]).play();
 
 setTimeout(function(){

--- a/demos/cli.js
+++ b/demos/cli.js
@@ -2,24 +2,28 @@
 
 var Player = require('../lib/player');
 
-new Player(function(d){
-  console.log(d);
-}).load([
-  { time: 1.2*0,     data: 'Come' },
-  { time: 1.2*500,   data: 'as' },
-  { time: 1.2*750,   data: 'you' },
-  { time: 1.2*875,   data: 'are' },
-  { time: 1.2*1500,  data: 'as' },
-  { time: 1.2*1750,  data: 'you' },
-  { time: 1.2*1825,  data: 'were' },
-  { time: 1.2*2675,  data: 'as' },
-  { time: 1.2*2750,  data: 'I' },
-  { time: 1.2*2850,  data: 'want' },
-  { time: 1.2*3000,  data: 'you' },
-  { time: 1.2*3250,  data: 'to' },
-  { time: 1.2*3500,  data: 'be' },
-]).play();
+var nirvana = [
+  { time: 0,    data: 'come' },
+  { time: 975,  data: 'as' },
+  { time: 1325, data: 'you' },
+  { time: 1675, data: 'are' },
+  { time: 2700, data: 'as' },
+  { time: 3150, data: 'you' },
+  { time: 3450, data: 'were' },
+  { time: 4463, data: 'as' },
+  { time: 4805, data: 'I' },
+  { time: 5180, data: 'want' },
+  { time: 5785, data: 'you' },
+  { time: 6580, data: 'to' },
+  { time: 6830, data: 'be' },
+  { time: 7580, data: 0 }
+];
 
-setTimeout(function(){
-  process.exit(0);
-}, 1.2*4000);
+var doer = function(e){
+  return {
+    string: (s) => console.log(s),
+    number: (n) => process.exit(n)
+  }[typeof e](e);
+};
+
+new Player(doer).load(nirvana).play();

--- a/demos/web/socket_player.js
+++ b/demos/web/socket_player.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var WebSocketServer = require('ws').Server,
     express = require('express'),
     app = express(),
@@ -12,12 +14,12 @@ var track = [
   { time: 600, data: {hue: 300, saturation: 100, lightness: 50}},
 ];
 
-webSocketServer = new WebSocketServer({port: 8080})
+var webSocketServer = new WebSocketServer({port: 8080});
 
 webSocketServer.on('connection', function(socket){
-  socket.on('message', function(message){
-    var sender = function(d){ socket.send(JSON.stringify(d)); };
-    var player = new Player(sender).load(track).play();
+  var sender = function(d){ socket.send(JSON.stringify(d)); };
+  socket.on('message', function(){
+    new Player(sender).load(track).play();
   });
 });
  
@@ -26,6 +28,6 @@ app.get('/', function(req, res){
 });
 
 app.listen(3000, function() {
-    console.log('Listening on port 3000');
+  console.log('Listening on port 3000');
 });
 

--- a/index.js
+++ b/index.js
@@ -2,5 +2,5 @@ module.exports = {
   player: require('./lib/player'),
   mux: require('./lib/muxer').mux,
   demux: require('./lib/muxer').demux
-}
+};
 

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "cov": "mocha --require blanket -R html-cov > coverage.html",
+    "cov": "nyc mocha",
     "code": "plato -d reports lib/*",
-    "lint": "jshint lib/*.js"
+    "lint": "jshint demos index.js lib test"
   },
   "repository": {
     "type": "git",
@@ -22,14 +22,14 @@
     "leierkasten"
   ],
   "devDependencies": {
-    "blanket": "^1.1.6",
-    "express": "~4",
-    "jshint": "^2.6.3",
-    "mocha": "~2",
-    "plato": "^1.4.0",
-    "should": "~4",
-    "sinon": "~1",
-    "ws": "0.5.x"
+    "express": "^4",
+    "jshint": "^2",
+    "mocha": "^3",
+    "nyc": "^10",
+    "plato": "^1",
+    "should": "^11",
+    "sinon": "^2",
+    "ws": "^2"
   },
   "dependencies": {
     "events": "~1",
@@ -37,7 +37,7 @@
   },
   "config": {
     "blanket": {
-      "pattern": "/barrel\/lib/"
+      "pattern": "/barrel/lib/"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Zach Rose",
   "name": "barrel",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "An abstract player for sequences of timed events.",
   "main": "index.js",
   "scripts": {

--- a/test/muxer.js
+++ b/test/muxer.js
@@ -1,9 +1,12 @@
-var should = require('should'),
-    muxer = require('../lib/muxer');
+'use strict';
+/* global describe, it */
 
-describe("Muxer", function(){
+var should = require('should');
+var muxer = require('../lib/muxer');
 
-  it("it can mux many named tracks into one track with many channels", function(){
+describe('Muxer', function(){
+
+  it('it can mux many named tracks into one track with many channels', function(){
       var muxed = muxer.mux({
         'count': [{time: 0, data: 'one'},{time: 10, data: 'two'}],
         'alphabet': [{time: 0, data: 'A'},{time: 10, data: 'B'},{time: 20, data: 'C'}],
@@ -21,7 +24,7 @@ describe("Muxer", function(){
       expected.forEach(function(event){ muxed.should.containEql(event); });
   });
   
-  it("can demux one track with many channels into many named tracks", function(){
+  it('can demux one track with many channels into many named tracks', function(){
     var muxed = [
       {time: 0,  channel: 'count',    data: 'one'},
       {time: 0,  channel: 'alphabet', data: 'A'},
@@ -34,7 +37,7 @@ describe("Muxer", function(){
       'count': [{time: 0, data: 'one'},{time: 10, data: 'two'}],
       'alphabet': [{time: 0, data: 'A'},{time: 10, data: 'B'},{time: 20, data: 'C'}],
       'numbers': [{time: 25, data: 3}]
-    }
+    };
     var actual = muxer.demux(muxed);
     should(actual).eql(expected);
   });

--- a/test/player.js
+++ b/test/player.js
@@ -1,10 +1,14 @@
+'use strict';
+/* globals afterEach, beforeEach, describe, it */
+/* jshint expr: true */
+
 require('should');
 
-var assert = require('assert'),
-    sinon = require('sinon'),
-    Player = require('../lib/player');
+var assert = require('assert');
+var sinon = require('sinon');
+var Player = require('../lib/player');
 
-describe("Player", function(){
+describe('Player', function(){
 
   var doer = sinon.spy(),
       player = null;
@@ -20,7 +24,7 @@ describe("Player", function(){
     this.clock.restore();
   });
 
-  it("accepts a doer", function(){
+  it('accepts a doer', function(){
     var doer = sinon.spy();
     var player = new Player(doer);
     player.doer.should.equal(doer);
@@ -32,7 +36,7 @@ describe("Player", function(){
     player.track.should.be.ok;
   });
 
-  describe("playback", function(){
+  describe('playback', function(){
 
     it('plays the right things at the right times', function(done){
       player.play();
@@ -46,7 +50,7 @@ describe("Player", function(){
 
     it('plays a multichannel track, calls the doer with the channel like so', function(){
       var multichannel = [
-        {time: 0, data: "A", channel: 'my_great_channel'}
+        {time: 0, data: 'A', channel: 'my_great_channel'}
       ];
       player.load(multichannel);
       player.play();
@@ -89,9 +93,9 @@ describe("Player", function(){
       player.pause();
       player.pause();
       done();
-    })
+    });
 
-    it("can be set to repeat", function(){
+    it('can be set to repeat', function(){
       player.repeat(true).play();
       this.clock.tick(400);
       player.doer.callCount.should.equal(4);
@@ -130,7 +134,7 @@ describe("Player", function(){
 
     });
 
-    describe("#isPlaying", function(){
+    describe('#isPlaying', function(){
 
       it('tells you if its playing', function(done){
         player.play();
@@ -145,7 +149,7 @@ describe("Player", function(){
 
     });
 
-    describe("#scrubTo", function(){
+    describe('#scrubTo', function(){
 
       it('can be scrubbed while not playing', function(){
         player.scrubTo(90);
@@ -162,7 +166,7 @@ describe("Player", function(){
       });
 
       it('ticks at the end of a scrub', function(){
-        var interested = sinon.spy()
+        var interested = sinon.spy();
         player.on('tick', interested);
         player.scrubTo(90);
         interested.lastCall.args[0].should.equal(90);
@@ -170,7 +174,7 @@ describe("Player", function(){
 
     });
 
-    describe("#jumpTo", function(){
+    describe('#jumpTo', function(){
 
       it('can jump to a new time by skipping over events', function(){
         player.play();
@@ -181,7 +185,7 @@ describe("Player", function(){
       });
 
       it('ticks at the end of a jump', function(){
-        var interested = sinon.spy()
+        var interested = sinon.spy();
         player.on('tick', interested);
         player.jumpTo(90);
         interested.lastCall.args[0].should.equal(90);
@@ -194,16 +198,16 @@ describe("Player", function(){
 
       it('can optionally play the last events', function(){
         var multichannel = [
-          {time: 0,   data: "A", channel: 'one'},
-          {time: 50,  data: "B", channel: 'one'},
-          {time: 100, data: "C", channel: 'two'},
-          {time: 150, data: "D", channel: 'two'}
+          {time: 0,   data: 'A', channel: 'one'},
+          {time: 50,  data: 'B', channel: 'one'},
+          {time: 100, data: 'C', channel: 'two'},
+          {time: 150, data: 'D', channel: 'two'}
         ];
         player.load(multichannel);
         player.jumpTo(125, true);
         player.doer.callCount.should.equal(2);
-        player.doer.lastCall.args[0].should.equal("C");
-        player.doer.lastCall.args[1].should.equal("two");
+        player.doer.lastCall.args[0].should.equal('C');
+        player.doer.lastCall.args[1].should.equal('two');
       });
 
     });


### PR DESCRIPTION
After a multi-year hiatus, dependencies are updated.

Also:
Replaces the `blanket` coverage reporter with `istanbul` (via `nyc`).
Applies linting to tests, demos, etc.
Adds polish to the timing of the Nirvana demo.
